### PR TITLE
Travis Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
 language: c
 compiler: gcc
-
+env:
+- PRODUCTION=1  # turn on strict errors for builds
 before_script: cd src
-
-script: make test
+script:
+- make test  # run tests
+- make  # make executable
+deploy:
+  provider: releases
+  skip_cleanup: true  # don't remove files
+  file: collascii  # upload this file
+  api_key:
+    secure: A3IZutdvZovr1s7efh66o96sGdY49b4tPg57usx/YyTGgF2LqIUY5M5wfrKRmCuey69v++8WFuODH9djr3y9JI0CI6pem/alFByp9AoL9gdZVeTWcl1k5PCSxux15xMcvd7PSO8UGhVCHq1A6XcBWjyHWDlE1zLAI+tVI6NrWd5clIPe3L+HyREkpK4tXQROD+dQ+htsAdr+6uY5ajcFdfqBM6ORHy4JB78/FO3cTj7Z702EWSwPfuUCSvWt2eEbbIyx8MH1XXczfqKKoSf7fGD60Ykr0hhOJXqbgeXBoHw/nooqxLTepI/nCWpfXU2ThzZV2Qmc86X2rTnja404mKzFxtIL+zJEj243PsCjbIXImiJNVyVP/J3rI0zYcr34pEwWd2cC+2AMf2NK50uh1GpRDtKmb5EmgD6nhnKKoU76mcmAuOJqzwaGLBazEWMjN/7K9Ny1iLb2PYDWPPRjLW06KO+vuZYthJtwH80DZ0JMZR5pbEe1he0kUciBGECLQPoJ+EDMS2eje5m2aOrfMJbd8ItEP4jjXzHd2WWsnbo8QYxU6Mf+yJp5EJzBu/dAmh0wTiI12JgPhKviIYrCmcYV8s+eW107uvj9QBd0J9JXJa5xdSUySdEl5dffIat5k5lJcmUh1X6/dgSfVR5mEiWqajQFXtk0vMMEFWIWhas=
+  on:
+    repo: olin/SoftSysCollascii
+    tags: true  # build on tagged releases only
+    branch: travis-updates

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ deploy:
   on:
     repo: olin/SoftSysCollascii
     tags: true  # build on tagged releases only
-    branch: travis-updates
+    branch: master

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,7 +26,10 @@ endif
 
 ## FILE-SPECIFIC MODIFICATIONS
 
-# Recipe doesn't work, using explicit rule instead
+# the main executable
+collascii: frontend.out
+	mv frontend.out collascii
+
 frontend.out: cursor.o fe_modes.o
 frontend.out: LDLIBS +=-lncurses
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,19 @@
 CC=gcc
 CFLAGS+=-Wall -std=gnu99
 
+version = $(shell git describe --always --tags --dirty)
+CFLAGS+="-DVERSION=version"
+
 # add debug annotations, turn off optimizations, and #define DEBUG
 # use in bash with `DEBUG=1 make <foo>`
 # use in fish with `env DEBUG=1 make <foo>`
 ifdef DEBUG
 CFLAGS+=-g -O0 -DDEBUG
+endif
+
+ifdef PRODUCTION
+# set warnings as errors
+CFLAGS+=-Werror
 endif
 
 ## EXAMPLES


### PR DESCRIPTION
This updates the tests run by travis to include building the project without errors, and uploading compiled versions automatically to GitHub releases.

Testing this is a little funky, I made two branches for it: [`bad-build`](https://github.com/olin/SoftSysCollascii/commits/bad-build) and [`release-test`](https://github.com/olin/SoftSysCollascii/commits/release-test).

`bad-build` adds an unused variable, which normally creates a warning but still compiles.  [When Travis builds with `PRODUCTION=1` it creates an error and fails ](https://travis-ci.com/olin/SoftSysCollascii/builds/109005602) (which is good).

`release-test` changes the release branch to `release-test` (normally Travis won't upload unless the tags are on `master`). I tagged that commit as `test` and made [a release for it](https://github.com/olin/SoftSysCollascii/releases/tag/test), and you can see that a `collascii` executable is uploaded there  (you can see the build log [here](https://travis-ci.com/olin/SoftSysCollascii/builds/109006350)).

This closes #25.