### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,89 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -354,7 +354,8 @@ Canvas *canvas_trimc(Canvas *orig, char ignore, bool right, bool bottom,
 }
 
 inline Canvas *canvas_trim(Canvas *orig, int right, int bottom, int left,
-                           int top) {}
+                           int top) {
+}
 
 /* Set a single character at position (x, y)
  *
@@ -567,7 +568,9 @@ int canvas_fprint_trim(FILE *stream, Canvas *canvas) {
  * Returns: the number of characters printed if successful, or a negative
  * value on output error from fprintf
  */
-int canvas_print(Canvas *canvas) { return canvas_fprint(stdout, canvas); }
+int canvas_print(Canvas *canvas) {
+  return canvas_fprint(stdout, canvas);
+}
 
 /* Create a canvas from a text file object.
  *

--- a/src/canvas_test.c
+++ b/src/canvas_test.c
@@ -111,7 +111,9 @@ void test_setup(void) {
   canvas_load_str(c1, load_str);
 }
 
-void test_teardown(void) { canvas_free(c1); }
+void test_teardown(void) {
+  canvas_free(c1);
+}
 
 MU_TEST(test_canvas_gcharyx) {
   mu_check(c1->rows[2][1] == canvas_gcharyx(c1, 2, 1));

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -11,7 +11,9 @@
  *
  * Initialized to (0, 0).
  */
-Cursor *cursor_new() { return cursor_newyx(0, 0); }
+Cursor *cursor_new() {
+  return cursor_newyx(0, 0);
+}
 
 /* Make a new cursor at a given position.
  */
@@ -69,9 +71,13 @@ void cursor_move_right(Cursor *cursor, View *view) {
   cursor->x++;
 }
 
-int cursor_x_to_canvas(Cursor *cursor) { return cursor->x + 1; }
+int cursor_x_to_canvas(Cursor *cursor) {
+  return cursor->x + 1;
+}
 
-int cursor_y_to_canvas(Cursor *cursor) { return cursor->y + 1; }
+int cursor_y_to_canvas(Cursor *cursor) {
+  return cursor->y + 1;
+}
 
 void cursor_key_to_move(int arrow, Cursor *cursor, View *view) {
   switch (arrow) {
@@ -104,4 +110,6 @@ int cursor_opposite_dir(int arrow) {
   return -1;
 }
 
-void cursor_free(Cursor *cursor) { free(cursor); }
+void cursor_free(Cursor *cursor) {
+  free(cursor);
+}

--- a/src/fe_modes.c
+++ b/src/fe_modes.c
@@ -47,13 +47,10 @@ typedef struct {
 } mode_brush_config_t;
 
 mode_brush_config_t mode_brush_config = {
-    .pattern = 'B',
-    .state = PAINT_OFF,
+    .pattern = 'B', .state = PAINT_OFF,
 };
 
-typedef struct {
-  Cursor *last_dir_change;
-} mode_insert_config_t;
+typedef struct { Cursor *last_dir_change; } mode_insert_config_t;
 
 mode_insert_config_t mode_insert_config = {NULL};
 
@@ -135,7 +132,9 @@ Mode_ID add_mod_canvas_mode(Mode_ID mode, int n) {
   return ((mode - mode_first) + n) % (mode_list_end - mode_first) + mode_first;
 }
 
-Mode_ID next_canvas_mode(Mode_ID mode) { return add_mod_canvas_mode(mode, 1); }
+Mode_ID next_canvas_mode(Mode_ID mode) {
+  return add_mod_canvas_mode(mode, 1);
+}
 
 Mode_ID previous_canvas_mode(Mode_ID mode) {
   return add_mod_canvas_mode(mode, -1);

--- a/src/frontend.c
+++ b/src/frontend.c
@@ -571,7 +571,7 @@ void finish(int sig) {
   }
 #endif
 
-  /* do your non-curses wrapup here */
+/* do your non-curses wrapup here */
 #ifdef LOG_TO_FILE
   if (logfile != NULL) {
     fclose(logfile);

--- a/src/util.h
+++ b/src/util.h
@@ -22,7 +22,9 @@
  * https://stackoverflow.com/a/1932371
  * https://stackoverflow.com/q/7762731
  */
-static inline void _log_unused(const int dummy, ...) { (void)dummy; }
+static inline void _log_unused(const int dummy, ...) {
+  (void)dummy;
+}
 
 #ifdef DEBUG
 // log to stderr if DEBUG is defined

--- a/src/view.c
+++ b/src/view.c
@@ -65,4 +65,6 @@ void view_pan_ch(int arrow, View *view) {
   }
 }
 
-void view_free(View *view) { free(view); }
+void view_free(View *view) {
+  free(view);
+}


### PR DESCRIPTION
This adds an explicit `.clang-format` file, based on the Google defaults but with single-line functions disabled.

TODO:
- [x] rebase off of master
- [x] format all files again