### PR TITLE
Compilation fixes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS+=-Wall -std=gnu99
+CFLAGS+=-Wall -std=gnu99 -no-pie
 
 version = $(shell git describe --always --tags --dirty)
 CFLAGS+="-DVERSION=\"$(version)\""

--- a/src/frontend.c
+++ b/src/frontend.c
@@ -136,7 +136,7 @@ void validate_arguments(arguments_t *arguments) {
   if (arguments->width < 0 || arguments->height < 0) {
     errmsg = "width and height settings must be positive";
   }
-  if (arguments->remote_port != '\0' && arguments->remote_host == '\0') {
+  if (arguments->remote_port[0] != '\0' && arguments->remote_host[0] == '\0') {
     errmsg = "server address must be specified";
   }
   if (arguments->connect_remote && arguments->load_file) {


### PR DESCRIPTION
I finally got around to upgrading to Ubuntu 19.10, and the included version of `gcc` (9.2.1) threw two new sets of errors that prevented me from compiling:

- a new warning about comparing pointers with character literals related to the cli parsing
- compilation failures related to linking and pies. After about 20 minutes of searching, my [limited understanding](https://stackoverflow.com/questions/2463150/what-is-the-fpie-option-for-position-independent-executables-in-gcc-and-ld) is that this is something related to libraries and where their memory is placed in the executable. I'm not sure if it is a problem with argtable inherently or just how we're using it. Regardless of what the actual issue is, not allowing it is a recent-ish new default for `gcc` and can be disabled with `-no-pie`, which I've done.
~~I'm not sure if this flag will be accepted by older versions though...~~ Travis is running gcc 5.4.0 and liked it just fine.
