### PR TITLE
Compiler warnings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS+=-Wall -std=gnu99 -no-pie
+CFLAGS+=-Wall -Wpedantic -std=gnu99 -no-pie
 
 version = $(shell git describe --always --tags --dirty)
 CFLAGS+="-DVERSION=\"$(version)\""

--- a/src/lib/argtable3.c
+++ b/src/lib/argtable3.c
@@ -542,7 +542,7 @@ static unsigned int enhanced_hash(arg_hashtable_t* h, void* k) {
 
 static unsigned int index_for(unsigned int tablelength, unsigned int hashvalue) {
     return (hashvalue % tablelength);
-};
+}
 
 arg_hashtable_t* arg_hashtable_create(unsigned int minsize, unsigned int (*hashfn)(void*), int (*eqfn)(void*, void*)) {
     arg_hashtable_t* h;

--- a/src/util.h
+++ b/src/util.h
@@ -44,19 +44,8 @@ static inline void _log_unused(const int dummy, ...) {
 // min/max macros
 // from https://stackoverflow.com/questions/3437404/min-and-max-in-c
 
-#define max(a, b)           \
-  ({                        \
-    __typeof__(a) _a = (a); \
-    __typeof__(b) _b = (b); \
-    _a > _b ? _a : _b;      \
-  })
-
-#define min(a, b)           \
-  ({                        \
-    __typeof__(a) _a = (a); \
-    __typeof__(b) _b = (b); \
-    _a < _b ? _a : _b;      \
-  })
+#define max(a,b) ((a) > (b) ? (a) : (b))
+#define min(a,b) ((a) < (b) ? (a) : (b))
 
 // ncurses-compatible CTRL+KEY definition
 // NOTE: c should be lowercase


### PR DESCRIPTION
- Add pedantic to default warnings
- Remove non-ISO statement expressions for min/max macros
